### PR TITLE
Update home page with Markdown CV

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,3 +3,72 @@
 Welcome to my tech portfolio and CV. Click below to see my academic work.
 
 [Go to Academia](/academic/)
+
+**Aleksei Trubin, Ph.D.**  <!-- Prague location originally commented out -->
+Prague, Czech Republic | [trubin.a@outlook.com](mailto:trubin.a@outlook.com) | [+420 774 511 297](tel:+420774511297) | [LinkedIn](https://www.linkedin.com/in/aleksei-trubin/) | [ResearchGate](https://www.researchgate.net/profile/Aleksei-Trubin) | [GitHub](https://github.com/alekseitrubin)
+
+### Summary
+
+**Geospatial Data Engineer** with over 9 years of professional experience and a Ph.D. in Geoinformatics, specializing in GIS and spatial database solutions tailored for forestry and environmental sectors. Proven expertise in SQL databases (PostgreSQL, Oracle, PostGIS), GIS platforms (ArcGIS, QGIS), and cloud-based data engineering with Azure Databricks and Snowflake. Demonstrated capability in developing optimized spatial data models and workflows, significantly enhancing performance and reducing costs. Experienced in Python-based automation, committed to driving technical innovation and leading data-driven strategies. Passionate mentor focused on empowering teams and delivering measurable business and environmental outcomes.
+
+### Skills
+
+- **Programming & Data Analysis:** Python (pandas, numpy, xarray, rioxarray, shapely, geopandas, fiona, GDAL, rasterio, scipy, scikit-learn, matplotlib, seaborn, plotly, dash, ArcPy), JavaScript, TypeScript, React Native, R, PySpark, FME, SQL (PostgreSQL, Oracle), MongoDB.
+- **Data Engineering:** AWS S3, AWS Lambda, Azure Databricks, Snowflake, dbt.
+- **Data Visualization:** Power BI, Tableau.
+- **Tools & Platforms:** VSCode, PyCharm, WebStorm, Jupyter, Colab, Microsoft Office (VBA), Docker, GitHub, GitLab, Linux.
+- **Project Management & Methodologies:** Jira, Confluence, Agile methodologies.
+- **GIS:** ArcGIS, QGIS.
+<!-- Big Data & Cloud Technologies: Azure Databricks, AWS Services -->
+
+### Work Experience
+
+#### Data Engineer (GIS), AT&T (US telecommunications company)
+*June 2024 – Present*
+
+- Migrated critical Oracle DB to PostgreSQL, **resulting in a 20% reduction in database management costs and a 30% increase in query performance efficiency** using Databricks.
+- Developed and optimized spatial queries using PostGIS, eliminating the need for expensive GIS products and maintaining robust spatial analysis capabilities, leading to significant cost savings.
+- Enhanced existing functions and procedures, **achieving up to a 50% increase in query speed** with PostgreSQL.
+- Automated validation processes from testing to production environments using FME and Python scripts, **reducing manual intervention by 70%** and improving deployment efficiency.
+
+#### Data Scientist / Research Assistant, Landviser (US environmental consulting)
+*March 2021 – May 2024*
+
+- **Achieved a 90% increase in client satisfaction and retention** by integrating Agile methodologies to streamline dashboard creation (using Python, Mapbox, Leaflet, PowerBI and ArcGIS Online) alongside comprehensive report writing.
+- **Increased site analysis accuracy to 91.7%** by processing and integrating geophysical, LiDAR, and optical data in Python, R, CloudCompare, QGIS and ESRI ArcGIS Pro during agriculture, archaeological and environmental projects.
+- **Boosted agricultural production yields by 22%** by applying machine learning techniques in Python to analyze climate, soil, and vegetation data.
+- **Reduced crop failure risks by 23.7%** by developing climate change impact models using statistical analysis.
+- **Streamlined data processing methodologies, as evidenced by a 30% reduction in processing time**, by implementing scripts and workflows utilizing Python.
+
+#### Data Scientist (Internship), Raincoat (Climate/Insurance Startup)
+*December 2020 – February 2021*
+
+- **Contributed to RS model development** by integrating 3 new data resources, enhancing model accuracy by 94%.
+
+#### Researcher (R1), Czech University Of Life Sciences In Prague (ČZU)
+*October 2019 – March 2024*
+
+- Conducted **complex data analysis** using programming, statistics and ML for tabular, GIS and remote sensing data processing, **resulting in 19 peer-reviewed articles with 114 citations**.
+- **Awarded 3 fellowships and 6 academic rewards**, including Rector's Prizes and Faculty Rewards, distinguishing in the **top 1% of R1 researchers** at the university for significant research contributions.
+- **Improved the effectiveness of the [TANABBO](https://github.com/tanabbo/tanabbo) open-source predictive model by developing two new modules** for spatial optimization, enhancing pest control strategies using Python and GRASS GIS.
+
+#### GIS Lead Specialist (Forestry) / FSC certification expert, Titan Group (Forest management enterprise)
+*May 2016 – September 2019*
+
+- **Created and enhanced GIS resolution 128-fold across an 8 million-hectare forest area** through data management and stakeholder communication.
+- Orchestrated efforts among businesses, NGOs, and government agencies to **configure 3,500 km² of forest conservation areas** using precise mapping and data analysis.
+- **Automated reporting for over 3,000 sites** using remote sensing imagery, saving €20,000 annually.
+- **Ensured annual FSC/PEFC standards compliance of 14 subsidiaries, with a 92.9% annual audit success rate**, by continuous stakeholder communication, training and control on improvements integration.
+
+### Education
+
+PhD Degree – Applied geoinformatics and remote sensing in forestry (2019 – 2024)  
+**Czech University Of Life Sciences In Prague (ČZU)**
+
+- **IBM** Python Data Science Professional Certificate ([Link](https://credentials.edx.org/credentials/5973ba29bf4344418d0a6d9bc943aeda)) (2023)
+- **CZU** Ecological Data Processing (R programming and statistics course) (2021)
+
+### Languages
+
+English – Advanced (C1), German – Elementary (A1), Czech – Elementary (A1), French – Elementary (A1), Russian – Native
+


### PR DESCRIPTION
## Summary
- removed raw LaTeX block on the home page
- added a clean Markdown version of the CV with sections for Summary, Skills, Work Experience, Education and Languages

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846a78591a48322b5bf9e0a0fa8eaaa